### PR TITLE
Add dependency for parsing SDP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <vertx.version>3.8.1</vertx.version>
         <jain-sip.version>1.2.317</jain-sip.version>
         <isup.version>8.0.112</isup.version>
+        <media-sdp.version>7.0.16</media-sdp.version>
         <pcap4j.version>1.8.2</pcap4j.version>
         <micrometer.version>1.2.1</micrometer.version>
         <spring-boot.version>2.1.8.RELEASE</spring-boot.version>
@@ -77,6 +78,27 @@
                 <groupId>org.mobicents.protocols.ss7.isup</groupId>
                 <artifactId>isup-impl</artifactId>
                 <version>${isup.version}</version>
+            </dependency>
+
+            <!-- SDP -->
+            <dependency>
+                <groupId>org.restcomm.media</groupId>
+                <artifactId>sdp</artifactId>
+                <version>${media-sdp.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>log4j-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Pcap4j -->


### PR DESCRIPTION
Add `org.restcomm.media:sdp` For parsing SDP and multipart content in SIP messages.