### PR TITLE
Modified: Default Java version 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,34 +11,34 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
-        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
+        <java.version>17</java.version>
+        <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
         <kotlin.version>1.7.21</kotlin.version>
         <kotlin-logging.version>3.0.5</kotlin-logging.version>
-        <vertx.version>4.4.4</vertx.version>
+        <vertx.version>4.4.5</vertx.version>
         <awssdk.version>2.20.65</awssdk.version>
         <jain-sip.version>1.2.317</jain-sip.version>
         <media-sdp.version>7.0.16</media-sdp.version>
         <ch-smpp.version>6.0.0-netty4-beta-2</ch-smpp.version>
         <pcap4j.version>1.8.2</pcap4j.version>
-        <micrometer.version>1.10.7</micrometer.version>
-        <ldaptive.version>2.1.2</ldaptive.version>
-        <spring-boot.version>2.7.10</spring-boot.version>
+        <micrometer.version>1.11.3</micrometer.version>
+        <ldaptive.version>2.2.0</ldaptive.version>
+        <spring-boot.version>3.1.4</spring-boot.version>
         <reflections.version>0.10.2</reflections.version>
-        <springdoc-openapi.version>1.7.0</springdoc-openapi.version>
-        <swagger.version>2.2.8</swagger.version>
-        <jackson.version>2.15.0</jackson.version>
+        <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
+        <swagger.version>2.2.16</swagger.version>
+        <jackson.version>2.15.2</jackson.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-net.version>3.9.0</commons-net.version>
-        <logback.version>1.2.6</logback.version>
-        <logback-webhook.version>1.0.5</logback-webhook.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <mockk.version>1.12.4</mockk.version>
+        <logback.version>1.4.11</logback.version>
+        <logback-webhook.version>1.0.6</logback-webhook.version>
+        <slf4j.version>2.0.9</slf4j.version>
+        <mockk.version>1.13.8</mockk.version>
         <sipunit.version>2.0.5</sipunit.version>
-        <testcontainers.version>1.17.5</testcontainers.version>
+        <testcontainers.version>1.19.1</testcontainers.version>
         <jna.version>5.13.0</jna.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <vertx-maven-plugin.version>1.0.24</vertx-maven-plugin.version>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <vertx-maven-plugin.version>1.0.28</vertx-maven-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
     </properties>
 
@@ -268,7 +268,7 @@
             <!-- Swagger -->
             <dependency>
                 <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-ui</artifactId>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${springdoc-openapi.version}</version>
             </dependency>
             <dependency>
@@ -300,6 +300,11 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
                 <artifactId>log4j-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
@@ -317,7 +322,7 @@
             </dependency>
             <dependency>
                 <groupId>io.mockk</groupId>
-                <artifactId>mockk</artifactId>
+                <artifactId>mockk-jvm</artifactId>
                 <version>${mockk.version}</version>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
Modified: Vertx version 4.4.5
Modified: Micrometer version 1.11.3
Modified: Ldaptive version 2.2.0
Modified: Spring Boot version 3.1.4
Modified: Springdoc OpenAPI version 2.2.0
Modified: Swagger version 2.2.16
Modified: Jackson version 2.15.2
Modified: Logback version 1.4.11
Modified: Slf4j version 2.0.9
Modified: Mockk version 1.13.8
Modified: Testcontainers version 1.19.1
Modified: Maven Surefire version 3.1.2
Modified: Vertx Maven Plugin version 1.0.28