### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
         <kotlin.version>1.7.21</kotlin.version>
         <kotlin-logging.version>3.0.5</kotlin-logging.version>
-        <vertx.version>4.5.2</vertx.version>
+        <vertx.version>4.5.3</vertx.version>
         <awssdk.version>2.20.65</awssdk.version>
         <jain-sip.version>1.2.317</jain-sip.version>
         <media-sdp.version>7.0.16</media-sdp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,30 +15,30 @@
         <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>
         <kotlin.version>1.7.21</kotlin.version>
         <kotlin-logging.version>3.0.5</kotlin-logging.version>
-        <vertx.version>4.5.1</vertx.version>
+        <vertx.version>4.5.2</vertx.version>
         <awssdk.version>2.20.65</awssdk.version>
         <jain-sip.version>1.2.317</jain-sip.version>
         <media-sdp.version>7.0.16</media-sdp.version>
         <ch-smpp.version>6.0.0-netty4-beta-2</ch-smpp.version>
         <pcap4j.version>1.8.2</pcap4j.version>
-        <micrometer.version>1.11.5</micrometer.version>
-        <ldaptive.version>2.2.0</ldaptive.version>
-        <spring-boot.version>3.1.4</spring-boot.version>
+        <micrometer.version>1.12.2</micrometer.version>
+        <ldaptive.version>2.3.0</ldaptive.version>
+        <spring-boot.version>3.1.8</spring-boot.version>
         <reflections.version>0.10.2</reflections.version>
         <springdoc-openapi.version>2.2.0</springdoc-openapi.version>
         <swagger.version>2.2.16</swagger.version>
-        <jackson.version>2.15.2</jackson.version>
+        <jackson.version>2.16.1</jackson.version>
         <jaxb.version>2.3.1</jaxb.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-net.version>3.9.0</commons-net.version>
         <logback.version>1.4.11</logback.version>
         <logback-webhook.version>1.0.6</logback-webhook.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <mockk.version>1.13.8</mockk.version>
+        <mockk.version>1.13.9</mockk.version>
         <sipunit.version>2.0.5</sipunit.version>
-        <testcontainers.version>1.19.1</testcontainers.version>
-        <jna.version>5.13.0</jna.version>
-        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <testcontainers.version>1.19.4</testcontainers.version>
+        <jna.version>5.14.0</jna.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <vertx-maven-plugin.version>1.0.28</vertx-maven-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
         <jackson.version>2.16.1</jackson.version>
         <jaxb.version>2.3.1</jaxb.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <commons-net.version>3.9.0</commons-net.version>
-        <logback.version>1.4.11</logback.version>
+        <commons-net.version>3.10.0</commons-net.version>
+        <logback.version>1.4.14</logback.version>
         <logback-webhook.version>1.0.6</logback-webhook.version>
         <slf4j.version>2.0.9</slf4j.version>
         <mockk.version>1.13.9</mockk.version>
         <sipunit.version>2.0.5</sipunit.version>
-        <testcontainers.version>1.19.4</testcontainers.version>
+        <testcontainers.version>1.19.5</testcontainers.version>
         <jna.version>5.14.0</jna.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <vertx-maven-plugin.version>1.0.28</vertx-maven-plugin.version>


### PR DESCRIPTION
Modified: Update Vert.x version to 4.5.2
Modified: Update Micrometer version to 1.12.2
Modified: Update Ldaptive version to 2.3.0
Modified: Update Spring Boot version to 3.1.8
Modified: Update Jackson version to 2.16.1
Modified: Update Mockk version to 1.13.9
Modified: Update Testcontainers version to 1.19.4
Modified: Update JNA version to 5.14.0
Modified: Update Maven Surefire Plugin version to 3.2.5